### PR TITLE
`netctl` runtime errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ scripts/%:
 	@echo "#!/bin/sh -e\n\n$(BINDIR)/linux-utils $* \"\$${@}\"" > $@
 
 $(CONFDIR)/eth0.toml.sample: $(CONFDIR)
-	@echo 'interface = "eth0"\n\n[IPv4]\n dhcp = true\n enable = true' > $@
+	@echo -e 'interface = "eth0"\n\n[IPv4]\n dhcp = true\n enable = true' > $@
 
 install: $(BINARIES) $(SCRIPTS) $(CONFIGS)

--- a/bin/cmd/netctl_up.go
+++ b/bin/cmd/netctl_up.go
@@ -57,6 +57,8 @@ This command takes either an interface (eth0, wlan1, etc.) or the word "all" whi
 }
 
 func netctlUpDo(iface string, n netctl.Netctl) error {
+	netctl.Verbose = verbose
+
 	if iface == "all" {
 		return netctlUpDoAll(n)
 	}
@@ -88,4 +90,5 @@ func init() {
 	netctlCmd.AddCommand(netctl_upCmd)
 
 	netctl_upCmd.Flags().StringVarP(&netctlDir, "basedir", "b", netctl.DefaultPath, "location of network config files")
+	netctl_upCmd.Flags().BoolVarP(&verbose, "", "v", false, "log dhcp, network calls")
 }

--- a/bin/cmd/netctl_up_test.go
+++ b/bin/cmd/netctl_up_test.go
@@ -4,17 +4,23 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 )
 
 func TestNetctl_Up(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
 	for _, test := range []struct {
 		name        string
 		args        []string
 		expectError bool
 	}{
 		{"all profiles, missing (default) dir", []string{"netctl", "up", "all"}, true},
-		{"all profiles, empty list", []string{"netctl", "up", "all", "-b", "/tmp"}, false},
+		{"all profiles, empty list", []string{"netctl", "up", "all", "-b", dir}, false},
 		{"all profiles, with errors", []string{"netctl", "up", "all", "-b", "testdata/netctl"}, true},
 		{"single iface, with errors", []string{"netctl", "up", "test0", "-b", "testdata/netctl"}, true},
 	} {

--- a/bin/cmd/root.go
+++ b/bin/cmd/root.go
@@ -58,6 +58,7 @@ var (
 	gid          int
 	groupName    string
 	netctlDir    string
+	verbose      bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -100,4 +101,5 @@ func reset() {
 	gid = -225
 	groupName = ""
 	netctlDir = netctl.DefaultPath
+	verbose = false
 }

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -3,33 +3,33 @@
 package netctl
 
 import (
-    "context"
-    "fmt"
-    "io/ioutil"
-    "os"
-    "path/filepath"
-    "strings"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/insomniacslk/dhcp/dhcpv4"
-    "github.com/pelletier/go-toml"
-    "github.com/vishvananda/netlink"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/pelletier/go-toml"
+	"github.com/vishvananda/netlink"
 )
 
 type netlinkHandle interface {
-    LinkSetDown(netlink.Link) error
-    LinkSetUp(netlink.Link) error
-    AddrAdd(netlink.Link, *netlink.Addr) error
-    RouteAdd(*netlink.Route) error
-    LinkByName(string) (netlink.Link, error)
+	LinkSetDown(netlink.Link) error
+	LinkSetUp(netlink.Link) error
+	AddrAdd(netlink.Link, *netlink.Addr) error
+	RouteAdd(*netlink.Route) error
+	LinkByName(string) (netlink.Link, error)
 }
 
 type dhcpOfferer interface {
-    DiscoverOffer(context.Context, ...dhcpv4.Modifier) (*dhcpv4.DHCPv4, error)
+	DiscoverOffer(context.Context, ...dhcpv4.Modifier) (*dhcpv4.DHCPv4, error)
 }
 
 var (
-    handle  netlinkHandle
-    dclient dhcpOfferer
+	handle  netlinkHandle
+	dclient dhcpOfferer
 )
 
 const DefaultPath = "/etc/vinyl/network.d"
@@ -37,72 +37,72 @@ const DefaultPath = "/etc/vinyl/network.d"
 // Netctl provides access to the files at /etc/vinyl/network
 // which govern network connections on vinyl systems
 type Netctl struct {
-    Profiles []Profile
+	Profiles []Profile
 }
 
 // NewDefaults calls New with all of the default values
 func NewDefaults() (Netctl, error) {
-    return New(DefaultPath)
+	return New(DefaultPath)
 }
 
 // New returns a new Netctl
 func New(p string) (n Netctl, err error) {
-    handle, err = netlink.NewHandle()
-    if err != nil {
-        return
-    }
+	handle, err = netlink.NewHandle()
+	if err != nil {
+		return
+	}
 
-    n = Netctl{}
+	n = Netctl{}
 
-    err = n.parse(p)
+	err = n.parse(p)
 
-    return
+	return
 }
 
 // Profile returns the configured profile for this interface
 func (n Netctl) Profile(iface string) (p Profile, err error) {
-    for _, p = range n.Profiles {
-        if p.Interface == iface {
-            return
-        }
-    }
+	for _, p = range n.Profiles {
+		if p.Interface == iface {
+			return
+		}
+	}
 
-    return Profile{}, fmt.Errorf("interface %s is not configured", iface)
+	return Profile{}, fmt.Errorf("interface %s is not configured", iface)
 }
 
 // parse reads all config files in n.path and updates n.profiles
 // containing them all
 func (n *Netctl) parse(p string) error {
-    n.Profiles = make([]Profile, 0)
+	n.Profiles = make([]Profile, 0)
 
-    return filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
+	return filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 
-        if strings.HasSuffix(info.Name(), ".toml") {
-            p, err := readProfile(path)
-            if err != nil {
-                return err
-            }
+		if strings.HasSuffix(info.Name(), ".toml") {
+			p, err := readProfile(path)
+			if err != nil {
+				return err
+			}
 
-            n.Profiles = append(n.Profiles, p)
-        }
+			n.Profiles = append(n.Profiles, p)
+		}
 
-        return nil
-    })
+		return nil
+	})
 }
 
 // readProfile will... read a profile
 func readProfile(filename string) (p Profile, err error) {
-    p = NewProfile()
+	p = NewProfile()
 
-    d, err := ioutil.ReadFile(filename)
-    if err != nil {
-        return
-    }
+	d, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
 
-    err = toml.Unmarshal(d, &p)
+	err = toml.Unmarshal(d, &p)
 
-    return
+	return
 }

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -35,6 +35,9 @@ var (
 
 const DefaultPath = "/etc/vinyl/network.d"
 
+// Log calls
+var Verbose = false
+
 // Netctl provides access to the files at /etc/vinyl/network
 // which govern network connections on vinyl systems
 type Netctl struct {

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// netlink client
 type netlinkHandle interface {
 	LinkSetDown(netlink.Link) error
 	LinkSetUp(netlink.Link) error
@@ -23,13 +24,13 @@ type netlinkHandle interface {
 	LinkByName(string) (netlink.Link, error)
 }
 
-type dhcpOfferer interface {
+// dhcp4 dhcp client
+type dhcpOfferer4 interface {
 	DiscoverOffer(context.Context, ...dhcpv4.Modifier) (*dhcpv4.DHCPv4, error)
 }
 
 var (
-	handle  netlinkHandle
-	dclient dhcpOfferer
+	handle netlinkHandle
 )
 
 const DefaultPath = "/etc/vinyl/network.d"

--- a/netctl/netctl_test.go
+++ b/netctl/netctl_test.go
@@ -3,50 +3,50 @@
 package netctl
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestNewDefaults(t *testing.T) {
-    _, err := NewDefaults()
-    if err == nil {
-        t.Fatalf("expected error")
-    }
+	_, err := NewDefaults()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
 }
 
 func TestNew(t *testing.T) {
-    for _, test := range []struct {
-        path        string
-        expectError bool
-    }{
-        {"testdata/happy-path", false},
-        {"testdata/mangled", true},
-    } {
-        t.Run(test.path, func(t *testing.T) {
-            _, err := New(test.path)
-            if err == nil && test.expectError {
-                t.Errorf("expected error")
-            } else if err != nil && !test.expectError {
-                t.Errorf("unexpected error: %#v", err)
-            }
-        })
-    }
+	for _, test := range []struct {
+		path        string
+		expectError bool
+	}{
+		{"testdata/happy-path", false},
+		{"testdata/mangled", true},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			_, err := New(test.path)
+			if err == nil && test.expectError {
+				t.Errorf("expected error")
+			} else if err != nil && !test.expectError {
+				t.Errorf("unexpected error: %#v", err)
+			}
+		})
+	}
 }
 
 func TestNetctl_Profile(t *testing.T) {
-    n := Netctl{
-        Profiles: []Profile{
-            {Interface: "test0"},
-            {Interface: "test1"},
-        },
-    }
+	n := Netctl{
+		Profiles: []Profile{
+			{Interface: "test0"},
+			{Interface: "test1"},
+		},
+	}
 
-    _, err := n.Profile("test0")
-    if err != nil {
-        t.Errorf("unexpected error: %#v", err)
-    }
+	_, err := n.Profile("test0")
+	if err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
 
-    _, err = n.Profile("eth0")
-    if err == nil {
-        t.Errorf("expected error")
-    }
+	_, err = n.Profile("eth0")
+	if err == nil {
+		t.Errorf("expected error")
+	}
 }

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -61,8 +61,8 @@ type Profile struct {
 	// link points to the underlying netlink object
 	link netlink.Link
 
-	// dhcp client
-	dclient dhcpOfferer
+	// dhcp clients
+	dclient4 dhcpOfferer4
 }
 
 // NewProfile returns a Profile with initial defaults set
@@ -168,9 +168,14 @@ func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
 }
 
 func (p Profile) negotiateIPV4() (address, gateway net.IP, netmask net.IPMask, err error) {
-	log.Printf("negotiating eth0")
+	if p.dclient4 == nil {
+		p.dclient4, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
+		if err != nil {
+			return
+		}
+	}
 
-	offer, err := p.dclient.DiscoverOffer(context.Background())
+	offer, err := p.dclient4.DiscoverOffer(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -139,7 +139,11 @@ func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
 
 func (p Profile) negotiateIPV4() (address, gateway net.IP, netmask net.IPMask, err error) {
 	if p.dclient4 == nil {
-		p.dclient4, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
+		if Verbose {
+			p.dclient4, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
+		} else {
+			p.dclient4, err = nclient4.New(p.Interface)
+		}
 		if err != nil {
 			return
 		}

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -79,6 +79,12 @@ func (p Profile) Up() (err error) {
 		return
 	}
 
+	log.Print("bringing if up")
+	err = p.BringUp()
+	if err != nil {
+		panic(err)
+	}
+
 	for idx, addr := range []Address{
 		p.IPv4,
 		p.IPv6,
@@ -118,8 +124,8 @@ func (p Profile) Up() (err error) {
 		}
 	}
 
-	log.Printf("ready to bring up")
-	return p.BringUp()
+	log.Printf("ready")
+	return
 }
 
 // Down will bring an interface down
@@ -136,12 +142,6 @@ func (p Profile) Down() (err error) {
 // 4. Take the interface back down (to allow netlink to control the iface)
 // 5. Return
 func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
-	log.Print("bringing if up")
-	err = p.BringUp()
-	if err != nil {
-		panic(err)
-	}
-
 	if p.dclient == nil {
 		log.Print("no dhcp client, creating")
 
@@ -154,8 +154,6 @@ func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
 	}
 
 	log.Print("defering dropping (so we can bring it up after setting up")
-	// Bring back up after setting address
-	defer p.Down()
 
 	switch idx {
 	case 0:

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -174,7 +174,8 @@ func (p Profile) SetGateway(a Address) (err error) {
 	route := &netlink.Route{
 		Scope:     netlink.SCOPE_UNIVERSE,
 		LinkIndex: p.link.Attrs().Index,
-		Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: net.CIDRMask(32, 32)},
+		Src:       a.AddressParsed,
+		Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: a.NetmaskParsed},
 	}
 
 	return handle.RouteAdd(route)

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -3,128 +3,128 @@
 package netctl
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "net"
+	"context"
+	"fmt"
+	"log"
+	"net"
 
-    "github.com/insomniacslk/dhcp/dhcpv4"
-    "github.com/insomniacslk/dhcp/dhcpv4/nclient4"
-    "github.com/vishvananda/netlink"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
+	"github.com/vishvananda/netlink"
 )
 
 // Address holds the configuration necessary for setting
 // an interface's IP address, including both manual and
 // dhcp settings
 type Address struct {
-    Address       string `toml:"address,omitempty"`
-    AddressParsed net.IP `toml:"-"`
+	Address       string `toml:"address,omitempty"`
+	AddressParsed net.IP `toml:"-"`
 
-    Netmask       string     `toml:"netmask,omitempty"`
-    NetmaskParsed net.IPMask `toml:"-"`
+	Netmask       string     `toml:"netmask,omitempty"`
+	NetmaskParsed net.IPMask `toml:"-"`
 
-    Gateway       string `toml:"gateway,omitempty"`
-    GatewayParsed net.IP `toml:"-"`
+	Gateway       string `toml:"gateway,omitempty"`
+	GatewayParsed net.IP `toml:"-"`
 
-    // Enable needs to be true in order to configure
-    Enable bool `toml:"enable,omitempty"`
+	// Enable needs to be true in order to configure
+	Enable bool `toml:"enable,omitempty"`
 
-    // DHCP true means Address/ Netmask/ Gateway can be ignored
-    // (if set, they're ignored anyway)
-    DHCP bool `toml:"dhcp,omitempty"`
+	// DHCP true means Address/ Netmask/ Gateway can be ignored
+	// (if set, they're ignored anyway)
+	DHCP bool `toml:"dhcp,omitempty"`
 }
 
 // Parse will turn various user specified components of an Address
 // into net.IP/net.IPMask types
 func (a *Address) Parse() {
-    if a.Address != "" {
-        a.AddressParsed = net.ParseIP(a.Address)
-    }
+	if a.Address != "" {
+		a.AddressParsed = net.ParseIP(a.Address)
+	}
 
-    if a.Netmask != "" {
-        a.NetmaskParsed = net.IPMask(net.ParseIP(a.Netmask))
-    }
+	if a.Netmask != "" {
+		a.NetmaskParsed = net.IPMask(net.ParseIP(a.Netmask))
+	}
 
-    if a.Gateway != "" {
-        a.GatewayParsed = net.ParseIP(a.Gateway)
-    }
+	if a.Gateway != "" {
+		a.GatewayParsed = net.ParseIP(a.Gateway)
+	}
 
-    return
+	return
 }
 
 // Profile contains configuration and data for an interface
 type Profile struct {
-    Interface string  `toml:"interface"`
-    IPv4      Address `toml:",omitempty"`
-    IPv6      Address `toml:",omitempty"`
+	Interface string  `toml:"interface"`
+	IPv4      Address `toml:",omitempty"`
+	IPv6      Address `toml:",omitempty"`
 
-    // link points to the underlying netlink object
-    link netlink.Link
+	// link points to the underlying netlink object
+	link netlink.Link
 
-    // dhcp client
-    dclient dhcpOfferer
+	// dhcp client
+	dclient dhcpOfferer
 }
 
 // NewProfile returns a Profile with initial defaults set
 func NewProfile() Profile {
-    return Profile{}
+	return Profile{}
 }
 
 // Up will bring an interface up
 func (p Profile) Up() (err error) {
-    log.Printf("Bringing interface %q up", p.Interface)
+	log.Printf("Bringing interface %q up", p.Interface)
 
-    p.link, err = handle.LinkByName(p.Interface)
-    if err != nil {
-        return
-    }
+	p.link, err = handle.LinkByName(p.Interface)
+	if err != nil {
+		return
+	}
 
-    for idx, addr := range []Address{
-        p.IPv4,
-        p.IPv6,
-    } {
-        log.Printf("idx: %d, addr: %#v", idx, addr)
-        if !addr.Enable {
-            log.Printf("not enabled; continue")
-            continue
-        }
+	for idx, addr := range []Address{
+		p.IPv4,
+		p.IPv6,
+	} {
+		log.Printf("idx: %d, addr: %#v", idx, addr)
+		if !addr.Enable {
+			log.Printf("not enabled; continue")
+			continue
+		}
 
-        log.Printf("enabled!")
+		log.Printf("enabled!")
 
-        addr.Parse()
+		addr.Parse()
 
-        log.Printf("addr parsed into %#v", addr)
+		log.Printf("addr parsed into %#v", addr)
 
-        if addr.DHCP {
-            log.Printf("doing dhcp")
-            err = p.PopulateFromDHCP(idx, &addr)
-            if err != nil {
-                return
-            }
-        }
+		if addr.DHCP {
+			log.Printf("doing dhcp")
+			err = p.PopulateFromDHCP(idx, &addr)
+			if err != nil {
+				return
+			}
+		}
 
-        log.Printf("got some dhcp config, addr is now: %#v", addr)
+		log.Printf("got some dhcp config, addr is now: %#v", addr)
 
-        for _, f := range []func(Address) error{
-            p.SetAddress,
-            p.SetGateway,
-        } {
-            log.Printf("doing func %#v", f)
+		for _, f := range []func(Address) error{
+			p.SetAddress,
+			p.SetGateway,
+		} {
+			log.Printf("doing func %#v", f)
 
-            err = f(addr)
-            if err != nil {
-                panic(err)
-            }
-        }
-    }
+			err = f(addr)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
 
-    log.Printf("ready to bring up")
-    return p.BringUp()
+	log.Printf("ready to bring up")
+	return p.BringUp()
 }
 
 // Down will bring an interface down
 func (p Profile) Down() (err error) {
-    return handle.LinkSetDown(p.link)
+	return handle.LinkSetDown(p.link)
 }
 
 // PopulateFromDHCP accepts an index (where 0 is IPv4, and 1 is IPv6)
@@ -136,86 +136,86 @@ func (p Profile) Down() (err error) {
 // 4. Take the interface back down (to allow netlink to control the iface)
 // 5. Return
 func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
-    if p.dclient == nil {
-        log.Print("no dhcp client, creating")
+	log.Print("bringing if up")
+	err = p.BringUp()
+	if err != nil {
+		panic(err)
+	}
 
-        p.dclient, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
-        if err != nil {
-            panic(err)
-        }
+	if p.dclient == nil {
+		log.Print("no dhcp client, creating")
 
-        log.Printf("dclient: %#v", p.dclient)
-    }
+		p.dclient, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
+		if err != nil {
+			panic(err)
+		}
 
-    log.Print("bringing if up")
-    err = p.BringUp()
-    if err != nil {
-        panic(err)
-    }
+		log.Printf("dclient: %#v", p.dclient)
+	}
 
-    log.Print("defering dropping (so we can bring it up after setting up")
-    // Bring back up after setting address
-    defer p.Down()
+	log.Print("defering dropping (so we can bring it up after setting up")
+	// Bring back up after setting address
+	defer p.Down()
 
-    switch idx {
-    case 0:
-        log.Print("idx is 0, meaning this is for an IPv4 network")
-        a.AddressParsed, a.GatewayParsed, a.NetmaskParsed, err = p.negotiateIPV4()
+	switch idx {
+	case 0:
+		log.Print("idx is 0, meaning this is for an IPv4 network")
+		a.AddressParsed, a.GatewayParsed, a.NetmaskParsed, err = p.negotiateIPV4()
 
-    default:
-        err = fmt.Errorf("unknown index #%d", idx)
-    }
+	default:
+		err = fmt.Errorf("unknown index #%d", idx)
+	}
 
-    return
+	return
 }
 
 func (p Profile) negotiateIPV4() (address, gateway net.IP, netmask net.IPMask, err error) {
-    log.Printf("negotiating eth0")
+	log.Printf("negotiating eth0")
 
-    offer, err := p.dclient.DiscoverOffer(context.Background())
-    if err != nil {
-        panic(err)
-    }
+	offer, err := p.dclient.DiscoverOffer(context.Background())
+	if err != nil {
+		panic(err)
+	}
 
-    log.Printf("got:\n%#v\n%v", offer, offer)
+	log.Printf("got:\n%#v\n%v", offer, offer)
 
-    address = offer.YourIPAddr
-    netmask = net.IPMask(net.IP(offer.Options.Get(dhcpv4.OptionSubnetMask)))
-    gateway = net.IP(offer.Options.Get(dhcpv4.OptionRouter))
+	address = offer.YourIPAddr
+	netmask = net.IPMask(net.IP(offer.Options.Get(dhcpv4.OptionSubnetMask)))
+	gateway = net.IP(offer.Options.Get(dhcpv4.OptionRouter))
 
-    return
+	return
 }
 
 // SetAddress uses netlink to set the address of an interface
 func (p Profile) SetAddress(a Address) (err error) {
-    ipConfig := &netlink.Addr{
-        IPNet: &net.IPNet{
-            IP:   a.AddressParsed,
-            Mask: a.NetmaskParsed,
-        },
-    }
+	ipConfig := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   a.AddressParsed,
+			Mask: a.NetmaskParsed,
+		},
+	}
 
-    log.Printf("configuring address %#v", ipConfig)
+	log.Printf("configuring address %#v", ipConfig)
 
-    return handle.AddrAdd(p.link, ipConfig)
+	return handle.AddrAdd(p.link, ipConfig)
 }
 
 // SetGateway uses netlink to set the gateway of an interface
 func (p Profile) SetGateway(a Address) (err error) {
-    route := &netlink.Route{
-        Scope:     netlink.SCOPE_UNIVERSE,
-        LinkIndex: p.link.Attrs().Index,
-        Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: net.CIDRMask(32, 32)},
-    }
+	route := &netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: p.link.Attrs().Index,
+		Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: net.CIDRMask(32, 32)},
+	}
 
-    log.Printf("adding route %#v", route)
+	log.Printf("adding route %#v", route)
 
-    return handle.RouteAdd(route)
+	return handle.RouteAdd(route)
 }
 
 // BringUp uses netlink to bring an interface up
 func (p Profile) BringUp() (err error) {
-    log.Printf("bringing up")
+	log.Printf("bringing up")
 
-    return handle.LinkSetUp(p.link)
+	return handle.LinkSetUp(p.link)
 }

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -139,7 +139,7 @@ func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
     if p.dclient == nil {
         log.Print("no dhcp client, creating")
 
-        p.dclient, err = nclient4.New(p.link.Attrs().Name)
+        p.dclient, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
         if err != nil {
             panic(err)
         }

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -181,8 +181,7 @@ func (p Profile) SetGateway(a Address) (err error) {
 	route := &netlink.Route{
 		Scope:     netlink.SCOPE_UNIVERSE,
 		LinkIndex: p.link.Attrs().Index,
-		Src:       a.AddressParsed,
-		Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: a.NetmaskParsed},
+		Gw:        a.GatewayParsed,
 	}
 
 	return wrap("SetGateway", handle.RouteAdd(route))

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -5,7 +5,6 @@ package netctl
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -72,59 +71,44 @@ func NewProfile() Profile {
 
 // Up will bring an interface up
 func (p Profile) Up() (err error) {
-	log.Printf("Bringing interface %q up", p.Interface)
-
 	p.link, err = handle.LinkByName(p.Interface)
 	if err != nil {
 		return
 	}
 
-	log.Print("bringing if up")
 	err = p.BringUp()
 	if err != nil {
-		panic(err)
+		return
 	}
 
 	for idx, addr := range []Address{
 		p.IPv4,
 		p.IPv6,
 	} {
-		log.Printf("idx: %d, addr: %#v", idx, addr)
 		if !addr.Enable {
-			log.Printf("not enabled; continue")
 			continue
 		}
 
-		log.Printf("enabled!")
-
 		addr.Parse()
 
-		log.Printf("addr parsed into %#v", addr)
-
 		if addr.DHCP {
-			log.Printf("doing dhcp")
 			err = p.PopulateFromDHCP(idx, &addr)
 			if err != nil {
 				return
 			}
 		}
 
-		log.Printf("got some dhcp config, addr is now: %#v", addr)
-
 		for _, f := range []func(Address) error{
 			p.SetAddress,
 			p.SetGateway,
 		} {
-			log.Printf("doing func %#v", f)
-
 			err = f(addr)
 			if err != nil {
-				panic(err)
+				return
 			}
 		}
 	}
 
-	log.Printf("ready")
 	return
 }
 
@@ -142,22 +126,8 @@ func (p Profile) Down() (err error) {
 // 4. Take the interface back down (to allow netlink to control the iface)
 // 5. Return
 func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
-	if p.dclient == nil {
-		log.Print("no dhcp client, creating")
-
-		p.dclient, err = nclient4.New(p.Interface, nclient4.WithDebugLogger())
-		if err != nil {
-			panic(err)
-		}
-
-		log.Printf("dclient: %#v", p.dclient)
-	}
-
-	log.Print("defering dropping (so we can bring it up after setting up")
-
 	switch idx {
 	case 0:
-		log.Print("idx is 0, meaning this is for an IPv4 network")
 		a.AddressParsed, a.GatewayParsed, a.NetmaskParsed, err = p.negotiateIPV4()
 
 	default:
@@ -177,10 +147,8 @@ func (p Profile) negotiateIPV4() (address, gateway net.IP, netmask net.IPMask, e
 
 	offer, err := p.dclient4.DiscoverOffer(context.Background())
 	if err != nil {
-		panic(err)
+		return
 	}
-
-	log.Printf("got:\n%#v\n%v", offer, offer)
 
 	address = offer.YourIPAddr
 	netmask = net.IPMask(net.IP(offer.Options.Get(dhcpv4.OptionSubnetMask)))
@@ -198,8 +166,6 @@ func (p Profile) SetAddress(a Address) (err error) {
 		},
 	}
 
-	log.Printf("configuring address %#v", ipConfig)
-
 	return handle.AddrAdd(p.link, ipConfig)
 }
 
@@ -211,14 +177,10 @@ func (p Profile) SetGateway(a Address) (err error) {
 		Dst:       &net.IPNet{IP: a.GatewayParsed, Mask: net.CIDRMask(32, 32)},
 	}
 
-	log.Printf("adding route %#v", route)
-
 	return handle.RouteAdd(route)
 }
 
 // BringUp uses netlink to bring an interface up
 func (p Profile) BringUp() (err error) {
-	log.Printf("bringing up")
-
 	return handle.LinkSetUp(p.link)
 }

--- a/netctl/profile_test.go
+++ b/netctl/profile_test.go
@@ -3,164 +3,164 @@
 package netctl
 
 import (
-    "context"
-    "fmt"
-    "net"
-    "testing"
+	"context"
+	"fmt"
+	"net"
+	"testing"
 
-    "github.com/insomniacslk/dhcp/dhcpv4"
-    "github.com/vishvananda/netlink"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/vishvananda/netlink"
 )
 
 type testNetLinkHandle struct {
-    err bool
+	err bool
 }
 
 func (h testNetLinkHandle) LinkSetDown(_ netlink.Link) error {
-    if h.err {
-        return fmt.Errorf("an error")
-    }
+	if h.err {
+		return fmt.Errorf("an error")
+	}
 
-    return nil
+	return nil
 }
 
 func (h testNetLinkHandle) LinkSetUp(_ netlink.Link) error {
-    if h.err {
-        return fmt.Errorf("an error")
-    }
+	if h.err {
+		return fmt.Errorf("an error")
+	}
 
-    return nil
+	return nil
 }
 
 func (h testNetLinkHandle) AddrAdd(_ netlink.Link, _ *netlink.Addr) error {
-    if h.err {
-        return fmt.Errorf("an error")
-    }
+	if h.err {
+		return fmt.Errorf("an error")
+	}
 
-    return nil
+	return nil
 }
 
 func (h testNetLinkHandle) RouteAdd(_ *netlink.Route) error {
-    if h.err {
-        return fmt.Errorf("an error")
-    }
+	if h.err {
+		return fmt.Errorf("an error")
+	}
 
-    return nil
+	return nil
 }
 
 func (h testNetLinkHandle) LinkByName(_ string) (l netlink.Link, err error) {
-    l = &netlink.Dummy{netlink.NewLinkAttrs()}
+	l = &netlink.Dummy{netlink.NewLinkAttrs()}
 
-    if h.err {
-        err = fmt.Errorf("an error")
-    }
+	if h.err {
+		err = fmt.Errorf("an error")
+	}
 
-    return
+	return
 }
 
 type testDHCPClient struct {
-    err bool
+	err bool
 }
 
 func (c testDHCPClient) DiscoverOffer(_ context.Context, _ ...dhcpv4.Modifier) (o *dhcpv4.DHCPv4, err error) {
-    if c.err {
-        err = fmt.Errorf("an error")
-    }
+	if c.err {
+		err = fmt.Errorf("an error")
+	}
 
-    o = &dhcpv4.DHCPv4{
-        YourIPAddr: net.ParseIP("192.168.1.3"),
-        Options: dhcpv4.Options{
-            uint8(dhcpv4.OptionSubnetMask): []byte{0xff, 0xff, 0xff, 0x0},
-            uint8(dhcpv4.OptionRouter):     []byte{0xc0, 0xa8, 0x1, 0x1},
-        },
-    }
+	o = &dhcpv4.DHCPv4{
+		YourIPAddr: net.ParseIP("192.168.1.3"),
+		Options: dhcpv4.Options{
+			uint8(dhcpv4.OptionSubnetMask): []byte{0xff, 0xff, 0xff, 0x0},
+			uint8(dhcpv4.OptionRouter):     []byte{0xc0, 0xa8, 0x1, 0x1},
+		},
+	}
 
-    return
+	return
 }
 
 func TestAddress_Parse(t *testing.T) {
-    defer func() {
-        err := recover()
-        if err != nil {
-            t.Fatalf("unexpected panic %#v", err)
-        }
-    }()
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Fatalf("unexpected panic %#v", err)
+		}
+	}()
 
-    a := Address{
-        Address: "192.168.1.2",
-        Netmask: "255.255.255.0",
-        Gateway: "192.168.1.1",
-    }
+	a := Address{
+		Address: "192.168.1.2",
+		Netmask: "255.255.255.0",
+		Gateway: "192.168.1.1",
+	}
 
-    a.Parse()
+	a.Parse()
 }
 
 func TestUp(t *testing.T) {
-    nonDHCP := Profile{
-        Interface: "test0",
-        IPv4: Address{
-            Address: "192.168.1.2",
-            Netmask: "255.255.255.0",
-            Gateway: "192.168.1.1",
-            Enable:  true,
-            DHCP:    false,
-        },
-        IPv6: Address{
-            Address: "fd12:3456:789a:1::8",
-            Netmask: "ffffffffffffffff0000000000000000",
-            Gateway: "fd12:3456:789a:1::1",
-            Enable:  true,
-            DHCP:    false,
-        },
-    }
+	nonDHCP := Profile{
+		Interface: "test0",
+		IPv4: Address{
+			Address: "192.168.1.2",
+			Netmask: "255.255.255.0",
+			Gateway: "192.168.1.1",
+			Enable:  true,
+			DHCP:    false,
+		},
+		IPv6: Address{
+			Address: "fd12:3456:789a:1::8",
+			Netmask: "ffffffffffffffff0000000000000000",
+			Gateway: "fd12:3456:789a:1::1",
+			Enable:  true,
+			DHCP:    false,
+		},
+	}
 
-    ip4DHCP := Profile{
-        Interface: "test0",
-        IPv4: Address{
-            Enable: true,
-            DHCP:   true,
-        },
-        dclient: testDHCPClient{},
-    }
+	ip4DHCP := Profile{
+		Interface: "test0",
+		IPv4: Address{
+			Enable: true,
+			DHCP:   true,
+		},
+		dclient: testDHCPClient{},
+	}
 
-    ip4DHCPErr := Profile{
-        Interface: "test0",
-        IPv4: Address{
-            Enable: true,
-            DHCP:   true,
-        },
-        dclient: testDHCPClient{err: true},
-    }
+	ip4DHCPErr := Profile{
+		Interface: "test0",
+		IPv4: Address{
+			Enable: true,
+			DHCP:   true,
+		},
+		dclient: testDHCPClient{err: true},
+	}
 
-    ip4DHCPClientErr := Profile{
-        Interface: "test0",
-        IPv4: Address{
-            Enable: true,
-            DHCP:   true,
-        },
-    }
+	ip4DHCPClientErr := Profile{
+		Interface: "test0",
+		IPv4: Address{
+			Enable: true,
+			DHCP:   true,
+		},
+	}
 
-    for _, test := range []struct {
-        name        string
-        profile     Profile
-        handle      netlinkHandle
-        expectError bool
-    }{
-        {"happy path", nonDHCP, testNetLinkHandle{}, false},
-        {"netlink errors", nonDHCP, testNetLinkHandle{err: true}, true},
-        {"with dhcp", ip4DHCP, testNetLinkHandle{}, false},
-        {"with dhcp errors", ip4DHCPErr, testNetLinkHandle{}, true},
-        {"dhcp client errors", ip4DHCPClientErr, testNetLinkHandle{}, true},
-    } {
-        t.Run(test.name, func(t *testing.T) {
-            handle = test.handle
+	for _, test := range []struct {
+		name        string
+		profile     Profile
+		handle      netlinkHandle
+		expectError bool
+	}{
+		{"happy path", nonDHCP, testNetLinkHandle{}, false},
+		{"netlink errors", nonDHCP, testNetLinkHandle{err: true}, true},
+		{"with dhcp", ip4DHCP, testNetLinkHandle{}, false},
+		{"with dhcp errors", ip4DHCPErr, testNetLinkHandle{}, true},
+		{"dhcp client errors", ip4DHCPClientErr, testNetLinkHandle{}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handle = test.handle
 
-            err := test.profile.Up()
-            if err == nil && test.expectError {
-                t.Errorf("expected error")
-            } else if err != nil && !test.expectError {
-                t.Errorf("unexpected error: %#v", err)
-            }
-        })
-    }
+			err := test.profile.Up()
+			if err == nil && test.expectError {
+				t.Errorf("expected error")
+			} else if err != nil && !test.expectError {
+				t.Errorf("unexpected error: %#v", err)
+			}
+		})
+	}
 }

--- a/netctl/profile_test.go
+++ b/netctl/profile_test.go
@@ -120,7 +120,7 @@ func TestUp(t *testing.T) {
 			Enable: true,
 			DHCP:   true,
 		},
-		dclient: testDHCPClient{},
+		dclient4: testDHCPClient{},
 	}
 
 	ip4DHCPErr := Profile{
@@ -129,7 +129,7 @@ func TestUp(t *testing.T) {
 			Enable: true,
 			DHCP:   true,
 		},
-		dclient: testDHCPClient{err: true},
+		dclient4: testDHCPClient{err: true},
 	}
 
 	ip4DHCPClientErr := Profile{


### PR DESCRIPTION
(This PR pulls in some `go fmt` changes, which may be ignored by appending `w=1` to the URL query string)

The original version of `netctl` didn't work unless certain conditions (the link being up but unconfigured, for example) weren't met.

This PR removes such manual tasks, adds some DHCP logging, and fixes sample config created in installation.