### PR TITLE
Bring loopback devices up

### DIFF
--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,8 +36,13 @@ var (
 
 const DefaultPath = "/etc/vinyl/network.d"
 
-// Log calls
-var Verbose = false
+var (
+	// Location of dns resolver config
+	ResolvFile = "/etc/resolv.conf"
+
+	// Log calls, operations
+	Verbose = false
+)
 
 // Netctl provides access to the files at /etc/vinyl/network
 // which govern network connections on vinyl systems
@@ -107,6 +113,25 @@ func readProfile(filename string) (p Profile, err error) {
 	}
 
 	err = toml.Unmarshal(d, &p)
+
+	return
+}
+
+func wrap(s string, err error) error {
+	if err == nil {
+		return err
+	}
+
+	return fmt.Errorf("%s: %w", s, err)
+}
+
+func writeResolv(ns net.IP) (err error) {
+	r, err := os.Create(ResolvFile)
+	if err != nil {
+		return
+	}
+
+	_, err = r.WriteString(fmt.Sprintf("nameserver %s\n", ns.String()))
 
 	return
 }

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -93,7 +93,7 @@ func (n *Netctl) parse(p string) error {
 		if strings.HasSuffix(info.Name(), ".toml") {
 			p, err := readProfile(path)
 			if err != nil {
-				return err
+				return wrap(path, err)
 			}
 
 			n.Profiles = append(n.Profiles, p)

--- a/netctl/netctl_test.go
+++ b/netctl/netctl_test.go
@@ -3,6 +3,8 @@
 package netctl
 
 import (
+	"io/ioutil"
+	"net"
 	"testing"
 )
 
@@ -48,5 +50,42 @@ func TestNetctl_Profile(t *testing.T) {
 	_, err = n.Profile("eth0")
 	if err == nil {
 		t.Errorf("expected error")
+	}
+}
+
+func TestWriteResolve(t *testing.T) {
+	origResolv := ResolvFile
+	defer func() {
+		ResolvFile = origResolv
+	}()
+
+	for _, test := range []struct {
+		name        string
+		fn          string
+		expect      string
+		expectError bool
+	}{
+		{"happy path", "/tmp/resolv.conf", "nameserver 1.1.1.1\n", false},
+		{"no such dir", "/1/2/3/4/5/resovl.conf", "", true},
+		{"no write permission", "/no-access", "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ResolvFile = test.fn
+
+			ip := net.ParseIP("1.1.1.1")
+			err := writeResolv(ip)
+			if err == nil && test.expectError {
+				t.Errorf("expected error")
+			} else if err != nil && !test.expectError {
+				t.Errorf("unexpected error: %#v", err)
+			}
+
+			got, _ := ioutil.ReadFile(test.fn)
+			gots := string(got)
+
+			if test.expect != gots {
+				t.Errorf("expected %q, received %q", test.expect, gots)
+			}
+		})
 	}
 }

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -6,15 +6,10 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
 	"github.com/vishvananda/netlink"
-)
-
-var (
-	ResolvFile = "/etc/resolv.conf"
 )
 
 // Address holds the configuration necessary for setting
@@ -198,23 +193,4 @@ func (p Profile) SetGateway(a Address) (err error) {
 // BringUp uses netlink to bring an interface up
 func (p Profile) BringUp() (err error) {
 	return wrap("iface Up", handle.LinkSetUp(p.link))
-}
-
-func wrap(s string, err error) error {
-	if err == nil {
-		return err
-	}
-
-	return fmt.Errorf("%s: %w", s, err)
-}
-
-func writeResolv(ns net.IP) (err error) {
-	r, err := os.Create(ResolvFile)
-	if err != nil {
-		return
-	}
-
-	_, err = r.WriteString(fmt.Sprintf("nameserver %s\n", ns.String()))
-
-	return
 }

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -6,10 +6,23 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
 	"github.com/vishvananda/netlink"
+)
+
+var (
+	// Test whether an interface is loopback by testing whether the name
+	// is suggests loopback by convention.
+	//
+	// This is a potentially weak way of doing this; realistically a loopback
+	// device can be named anything, and can only reliably be tested by checking
+	// for the IFF_LOOPBACK flag.
+	//
+	// However, it's probably fine /shrug
+	loopback = regexp.MustCompile(`^lo[0-9]*$`)
 )
 
 // Address holds the configuration necessary for setting
@@ -81,6 +94,13 @@ func (p Profile) Up() (err error) {
 		return
 	}
 
+	// Loopback devices are special; we can go ahead and set them
+	// up the same way each time. In fact, the loopback file only needs
+	// the value of `Interface` to be set
+	if loopback.Match([]byte(p.Interface)) {
+		return p.UpLoopback()
+	}
+
 	for idx, addr := range []Address{
 		p.IPv4,
 		p.IPv6,
@@ -110,6 +130,11 @@ func (p Profile) Up() (err error) {
 	}
 
 	return
+}
+
+// UpLoopback brings a loopback device up
+func (p Profile) UpLoopback() (err error) {
+	return p.BringUp()
 }
 
 // Down will bring an interface down

--- a/netctl/profile.go
+++ b/netctl/profile.go
@@ -161,6 +161,10 @@ func (p *Profile) PopulateFromDHCP(idx int, a *Address) (err error) {
 		err = fmt.Errorf("unknown index #%d", idx)
 	}
 
+	if err != nil {
+		return
+	}
+
 	return writeResolv(nameserver)
 }
 

--- a/netctl/profile_test.go
+++ b/netctl/profile_test.go
@@ -96,6 +96,13 @@ func TestAddress_Parse(t *testing.T) {
 }
 
 func TestUp(t *testing.T) {
+	origResolv := ResolvFile
+	defer func() {
+		ResolvFile = origResolv
+	}()
+
+	ResolvFile = "/tmp/test-resolv.conf"
+
 	nonDHCP := Profile{
 		Interface: "test0",
 		IPv4: Address{

--- a/netctl/profile_test.go
+++ b/netctl/profile_test.go
@@ -140,6 +140,10 @@ func TestUp(t *testing.T) {
 		},
 	}
 
+	loopback := Profile{
+		Interface: "lo",
+	}
+
 	for _, test := range []struct {
 		name        string
 		profile     Profile
@@ -151,6 +155,7 @@ func TestUp(t *testing.T) {
 		{"with dhcp", ip4DHCP, testNetLinkHandle{}, false},
 		{"with dhcp errors", ip4DHCPErr, testNetLinkHandle{}, true},
 		{"dhcp client errors", ip4DHCPClientErr, testNetLinkHandle{}, true},
+		{"loopback", loopback, testNetLinkHandle{}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			handle = test.handle


### PR DESCRIPTION
`netctl` should handle loopback devices as a special case- they don't need gateways, masks, whatevers. That stuff is already handled by the kernel.